### PR TITLE
Login scene: database auth, UserDao CRUD, and tests

### DIFF
--- a/src/main/java/com/vila/controller/LoginController.java
+++ b/src/main/java/com/vila/controller/LoginController.java
@@ -1,6 +1,8 @@
 package com.vila.controller;
 
 import com.vila.SceneFactory;
+import com.vila.dao.UserDao;
+import com.vila.entity.User;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.control.PasswordField;
@@ -28,12 +30,47 @@ public class LoginController {
             return;
         }
 
-        errorLabel.setText("");
-        // TODO: authenticate against UserDao
+        try {
+            UserDao dao = UserDao.create();
+            User user = dao.findByUsername(username);
+
+            if (user == null || !user.getUserPassword().equals(password)) {
+                errorLabel.setText("Invalid username or password.");
+                return;
+            }
+
+            errorLabel.setText("");
+            if (sceneFactory != null) sceneFactory.showHome();
+
+        } catch (Exception e) {
+            errorLabel.setText("Something went wrong. Try again.");
+        }
     }
 
     @FXML
     private void onRegister() {
-        // TODO: show registration form
+        String username = usernameField.getText().trim();
+        String password = passwordField.getText();
+
+        if (username.isEmpty() || password.isEmpty()) {
+            errorLabel.setText("Please fill in all fields.");
+            return;
+        }
+
+        try {
+            UserDao dao = UserDao.create();
+
+            if (dao.findByUsername(username) != null) {
+                errorLabel.setText("Username already taken.");
+                return;
+            }
+
+            dao.insert(new User(username, password, "user"));
+            errorLabel.setText("");
+            if (sceneFactory != null) sceneFactory.showHome();
+
+        } catch (Exception e) {
+            errorLabel.setText("Something went wrong. Try again.");
+        }
     }
 }

--- a/src/main/java/com/vila/dao/UserDao.java
+++ b/src/main/java/com/vila/dao/UserDao.java
@@ -1,0 +1,65 @@
+package com.vila.dao;
+
+import com.vila.entity.User;
+import com.vila.util.DatabaseHelper;
+
+import java.sql.*;
+
+public class UserDao {
+
+    private final Connection connection;
+
+    public UserDao(Connection connection) {
+        this.connection = connection;
+    }
+
+    public static UserDao create() throws SQLException {
+        Connection conn = DatabaseHelper.getConnection();
+        DatabaseHelper.initTables(conn);
+        return new UserDao(conn);
+    }
+
+    public boolean insert(User user) throws SQLException {
+        String sql = "INSERT INTO user (user_name, user_password, user_role) VALUES (?, ?, ?)";
+        try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setString(1, user.getUserName());
+            stmt.setString(2, user.getUserPassword());
+            stmt.setString(3, user.getUserRole());
+            return stmt.executeUpdate() == 1;
+        }
+    }
+
+    public User findByUsername(String username) throws SQLException {
+        String sql = "SELECT * FROM user WHERE user_name = ?";
+        try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setString(1, username);
+            ResultSet rs = stmt.executeQuery();
+            if (rs.next()) {
+                return new User(
+                    rs.getString("user_name"),
+                    rs.getString("user_password"),
+                    rs.getString("user_role"),
+                    rs.getInt("user_id")
+                );
+            }
+        }
+        return null;
+    }
+
+    public boolean updatePassword(String username, String newPassword) throws SQLException {
+        String sql = "UPDATE user SET user_password = ? WHERE user_name = ?";
+        try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setString(1, newPassword);
+            stmt.setString(2, username);
+            return stmt.executeUpdate() == 1;
+        }
+    }
+
+    public boolean delete(String username) throws SQLException {
+        String sql = "DELETE FROM user WHERE user_name = ?";
+        try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setString(1, username);
+            return stmt.executeUpdate() == 1;
+        }
+    }
+}

--- a/src/main/java/com/vila/util/DatabaseHelper.java
+++ b/src/main/java/com/vila/util/DatabaseHelper.java
@@ -1,0 +1,71 @@
+package com.vila.util;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class DatabaseHelper {
+
+    private static final String DB_URL = "jdbc:sqlite:vila.db";
+
+    private static Connection connection;
+
+    public static Connection getConnection() throws SQLException {
+        if (connection == null || connection.isClosed()) {
+            connection = DriverManager.getConnection(DB_URL);
+        }
+        return connection;
+    }
+
+    public static Connection getInMemoryConnection() throws SQLException {
+        return DriverManager.getConnection("jdbc:sqlite::memory:");
+    }
+
+    public static void initTables(Connection conn) throws SQLException {
+        Statement stmt = conn.createStatement();
+
+        stmt.executeUpdate("""
+            CREATE TABLE IF NOT EXISTS user (
+                user_id       INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_name     TEXT NOT NULL UNIQUE,
+                user_password TEXT NOT NULL,
+                user_role     TEXT NOT NULL DEFAULT 'user'
+            )
+        """);
+
+        stmt.executeUpdate("""
+            CREATE TABLE IF NOT EXISTS item (
+                item_id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                item_name        TEXT NOT NULL,
+                item_description TEXT,
+                item_price       REAL NOT NULL,
+                item_quantity    INTEGER NOT NULL DEFAULT 0,
+                item_image_url   TEXT
+            )
+        """);
+
+        stmt.executeUpdate("""
+            CREATE TABLE IF NOT EXISTS cart (
+                cart_id    INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id    INTEGER NOT NULL,
+                item_id    INTEGER NOT NULL,
+                cart_count INTEGER NOT NULL DEFAULT 1,
+                FOREIGN KEY (user_id) REFERENCES user(user_id),
+                FOREIGN KEY (item_id) REFERENCES item(item_id)
+            )
+        """);
+
+        stmt.executeUpdate("""
+            CREATE TABLE IF NOT EXISTS orders (
+                order_id    INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id     INTEGER NOT NULL,
+                order_date  TEXT NOT NULL,
+                total_price REAL NOT NULL,
+                FOREIGN KEY (user_id) REFERENCES user(user_id)
+            )
+        """);
+
+        stmt.close();
+    }
+}

--- a/src/test/java/com/vila/dao/UserDaoTest.java
+++ b/src/test/java/com/vila/dao/UserDaoTest.java
@@ -1,0 +1,54 @@
+package com.vila.dao;
+
+import com.vila.entity.User;
+import com.vila.util.DatabaseHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UserDaoTest {
+
+    private UserDao dao;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        Connection conn = DatabaseHelper.getInMemoryConnection();
+        DatabaseHelper.initTables(conn);
+        dao = new UserDao(conn);
+    }
+
+    @Test
+    void testInsert() throws Exception {
+        User user = new User("nazar", "pass123", "user");
+        boolean result = dao.insert(user);
+        assertTrue(result);
+    }
+
+    @Test
+    void testFindByUsername() throws Exception {
+        dao.insert(new User("nazar", "pass123", "user"));
+        User found = dao.findByUsername("nazar");
+        assertNotNull(found);
+        assertEquals("nazar", found.getUserName());
+        assertEquals("user", found.getUserRole());
+    }
+
+    @Test
+    void testUpdatePassword() throws Exception {
+        dao.insert(new User("nazar", "oldpass", "user"));
+        boolean updated = dao.updatePassword("nazar", "newpass");
+        assertTrue(updated);
+        assertEquals("newpass", dao.findByUsername("nazar").getUserPassword());
+    }
+
+    @Test
+    void testDelete() throws Exception {
+        dao.insert(new User("nazar", "pass123", "user"));
+        boolean deleted = dao.delete("nazar");
+        assertTrue(deleted);
+        assertNull(dao.findByUsername("nazar"));
+    }
+}


### PR DESCRIPTION
Adds the working login and registration flow for Vila Activewear.

- DatabaseHelper sets up SQLite connection and creates all 4 tables on first run
- UserDao handles insert, findByUsername, updatePassword, and delete
- LoginController now checks credentials against the database and handles new account creation
- UserDaoTest covers all four CRUD operations using an in-memory SQLite database

Closes #2
